### PR TITLE
Redeployability Great Library Update - 10.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "eslint-config-taskcluster"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ caches:
   yarn: true
 env:
   global:
-  - DEBUG='taskcluster-lib-urls test'
+  - DEBUG='taskcluster-lib-azure test'
   - CXX=g++-4.8
 notifications:
   irc:
@@ -26,5 +26,5 @@ deploy:
     secure: LegnCcsUuXaAkG+1CqaSDvOnXjkgfrcB/SXOB5X1DI668Zny76ifnLzvBv1DRYnf7vc3cZy2dHEuAjsg0Ima1eanw0Pjyvh0SF8CPrlXuSPXuqFsbxsHsPtYj7BLCixRDG+4vTIhKIDKY0DFoLa6/HcLr0kyIuPOeJ7nkwKxjnPiCzv1stoBL3HujbodALPCPRo9eGZqv8MQu5Cuk+z2ZPRO05XrHxWfVfjBGCVIZqg9Sy/lzukFCNdpOdsv2YP4po4Kk7qcTTgDeZm5k/0i0oxWMlETasJOJI4EkZBWLX9YBu6ZE2kgr8x3S4E1PvHWgsoL9tYJgSFaQ51nE/w6IyTB1vLi65ZJRLO1YbYhJt+GNivEhDSZ7E6liwLiga+Sfc7bGaoJ2l0Ccas410hStXIM+rhgOem+Sr1CmplOb9aZ1B8Wdc9+3yev1myqqWp8KoDT1QCvWmf6OhWyjGGnyzasGAQhSaDa9E+81KgYUeDXB1V0DAnr64yBDbT8jzV30gdPzDUsZABowuiBALdKfg2+k27ZW7GaaTvE45equ5T8nFJr47GuYmaEkVgqHYeLa3g6DmHSr1/Z8PqXdXIP0ATkiXY2QgyN7Z93d0WcaIxF/2tMLFb30LQOOrLhPALKf1R8CyPSuiIc/NRugAWfJx6VuU6SNSLWb1hqt72XC9w=
   on:
     tags: true
-    repo: taskcluster/taskcluster-lib-urls
+    repo: taskcluster/taskcluster-lib-azure
     node: '10'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ MyTable.setup({
 });
 ```
 
+If desired, pass `accessLevel`; this defaults to `'read-write'` but can be set to `'read-only'`.
+
 Testing
 -------
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-# Taskcluster URL Building Library
+# Taskcluster Azure Shim
 
 [![Build Status](https://travis-ci.org/taskcluster/taskcluster-lib-azure.svg?branch=master)](https://travis-ci.org/taskcluster/taskcluster-lib-azure)
 [![npm](https://img.shields.io/npm/v/taskcluster-lib-azure.svg?maxAge=2592000)](https://www.npmjs.com/package/taskcluster-lib-azure)
 [![License](https://img.shields.io/badge/license-MPL%202.0-orange.svg)](http://mozilla.org/MPL/2.0)
 
-A simple library to generate URLs for various Taskcluster resources across our various deployment methods.
-
-This serves as both a simple shim for projects that use JavaScript but also is the reference implementation for
-how we define these paths.
+A simple library to allow using `azure-entities` and the like, with Taskcluster credentials.
 
 Changelog
 ---------
@@ -21,59 +18,18 @@ This is tested on and should run on any of Node.js `{8, 10}`.
 Usage
 -----
 
-This package exports several methods for generating URLs conditionally based on
-a root URL, as well as a few helper classes for generating URLs for a pre-determined
-root URL:
-
-* `api(rootUrl, service, version, path)` -> `String`
-* `apiReference(rootUrl, service, version)` -> `String`
-* `docs(rootUrl, path)` -> `String`
-* `exchangeReference(rootUrl, service, version)` -> `String`
-* `schema(rootUrl, service, version, schema)` -> `String`
-* `ui(rootUrl, path)` -> `String`
-* `testRootUrl()` -> `String`
-* `withRootUrl(rootUrl)` -> `Class` instance for above methods
-
-When the `rootUrl` is `https://taskcluster.net`, the generated URLs will be to the Heroku cluster. Otherwise they will follow the
-[spec defined in this project](https://github.com/taskcluster/taskcluster-lib-azure/tree/master/docs/azure-spec.md).
-
-`testRootUrl` is used to share a common `rootUrl` between various Taskcluster mocks in testing.
-
 ```js
-// Specifying root URL every time:
-const tcUrl = require('taskcluster-lib-url');
+const {sasCredentials} = require('taskcluster-lib-azure');
 
-tcUrl.api(rootUrl, 'auth', 'v1', 'foo/bar');
-tcUrl.schema(rootUrl, 'auth', 'v1', 'foo.yml');
-tcUrl.apiReference(rootUrl, 'auth', 'v1');
-tcUrl.exchangeReference(rootUrl, 'auth', 'v1');
-tcUrl.ui(rootUrl, 'foo/bar');
-tcUrl.docs(rootUrl, 'foo/bar');
-```
-
-```js
-// Specifying root URL in advance:
-const tcUrl = require('taskcluster-lib-url');
-
-const urls = tcUrl.withRoot(rootUrl);
-
-urls.api('auth', 'v1', 'foo/bar');
-urls.schema('auth', 'v1', 'foo.yml');
-urls.apiReference('auth', 'v1');
-urls.exchangeReference('auth', 'v1');
-urls.ui('foo/bar');
-urls.docs('foo/bar');
-```
-
-If you would like, you can set this up via [taskcluster-lib-loader](https://github.com/taskcluster/taskcluster-lib-loader) as follows:
-
-```js
-{
-  tcUrls: {
-    require: ['cfg'],
-    setup: ({cfg}) => withRootUrl(cfg.rootURl),
-  },
-}
+MyTable.setup({
+  credentials: sasCredentials({
+    accountId,     // azure account to use
+    tableName,     // table name in that account
+    rootUrl,       // TC rootUrl (used to find the auth service)
+    credentials,   // Taskcluster credentials
+  }), 
+  ...,
+});
 ```
 
 Testing

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
   "main": "./src/index.js",
   "devDependencies": {
     "eslint-config-taskcluster": "^3.1.0",
-    "mocha": "^5.1.1"
+    "mocha": "^5.1.1",
+    "nock": "^9.2.5",
+    "taskcluster-lib-urls": "^1.0.0"
+  },
+  "dependencies": {
+    "taskcluster-client": "^5.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,15 @@
+const taskcluster = require('taskcluster-client');
+
+/**
+ * Generate a `credentials` property for azure-entities or azure-blob-storage,
+ * that will fetch SAS credentials from the Auth service.
+ */
+exports.sasCredentials = ({accountId, tableName, rootUrl, credentials}) => {
+  const auth = new taskcluster.Auth({rootUrl, credentials});
+  return {
+    accountId,
+    sas: () => auth.azureTableSAS(accountId, tableName, 'read-write')
+      .then(res => res.sas),
+    minSASAuthExpiry: 15 * 60 * 1000,
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,11 @@ const taskcluster = require('taskcluster-client');
  * Generate a `credentials` property for azure-entities or azure-blob-storage,
  * that will fetch SAS credentials from the Auth service.
  */
-exports.sasCredentials = ({accountId, tableName, rootUrl, credentials}) => {
+exports.sasCredentials = ({accountId, tableName, rootUrl, credentials, accessLevel}) => {
   const auth = new taskcluster.Auth({rootUrl, credentials});
   return {
     accountId,
-    sas: () => auth.azureTableSAS(accountId, tableName, 'read-write')
+    sas: () => auth.azureTableSAS(accountId, tableName, accessLevel || 'read-write')
       .then(res => res.sas),
     minSASAuthExpiry: 15 * 60 * 1000,
   };

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,16 +1,16 @@
 const assert = require('assert');
 const {sasCredentials} = require('..');
 const nock = require('nock');
-var url  = require('url');
-const urls = require('taskcluster-lib-urls');
+const url  = require('url');
+const libUrls = require('taskcluster-lib-urls');
 
 suite('index_test.js', function() {
   let scope;
 
   const mockAzureTableSAS = (accessLevel) => {
-    const rootUrl = urls.testRootUrl();
+    const rootUrl = libUrls.testRootUrl();
     const azureTableSASPath = url.parse(
-      urls.api(rootUrl, 'auth', 'v1', `/azure/myaccount/table/mytable/${accessLevel}`)
+      libUrls.api(rootUrl, 'auth', 'v1', `/azure/myaccount/table/mytable/${accessLevel}`)
     ).pathname;
     scope = nock(rootUrl, {encodedQueryParams:true, allowUnmocked: true})
       .get(azureTableSASPath)
@@ -34,7 +34,7 @@ suite('index_test.js', function() {
     const creds = sasCredentials({
       accountId: 'myaccount',
       tableName: 'mytable',
-      rootUrl: urls.testRootUrl(),
+      rootUrl: libUrls.testRootUrl(),
       credentials: {},
     });
 
@@ -48,7 +48,7 @@ suite('index_test.js', function() {
     const creds = sasCredentials({
       accountId: 'myaccount',
       tableName: 'mytable',
-      rootUrl: urls.testRootUrl(),
+      rootUrl: libUrls.testRootUrl(),
       credentials: {},
       accessLevel: 'read-only',
     });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const {sasCredentials} = require('..');
+const nock = require('nock');
+var url  = require('url');
+const urls = require('taskcluster-lib-urls');
+
+suite('index_test.js', function() {
+  let scope;
+
+  setup(function() {
+    const rootUrl = urls.testRootUrl();
+    const azureTableSASPath = url.parse(
+      urls.api(rootUrl, 'auth', 'v1', '/azure/myaccount/table/mytable/read-write')
+    ).pathname;
+    scope = nock(rootUrl, {encodedQueryParams:true, allowUnmocked: true})
+      .get(azureTableSASPath)
+      .reply(200, function() {
+        return {
+          expiry: new Date().toJSON(),
+          sas: 'x=10&y=20',
+        };
+      });
+  });
+
+  teardown(function() {
+    assert(scope.isDone(), 'nock was not accessed');
+  });
+
+  test('fetches credentials', async function() {
+    const creds = sasCredentials({
+      accountId: 'myaccount',
+      tableName: 'mytable',
+      rootUrl: urls.testRootUrl(),
+      credentials: {},
+    });
+
+    assert.equal(creds.accountId, 'myaccount');
+    assert.equal(creds.minSASAuthExpiry, 15 * 60 * 1000);
+    assert.equal(await creds.sas(), 'x=10&y=20');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,16 @@ ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+amqplib@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.5.2.tgz#d2d7313c7ffaa4d10bcf1e6252de4591b6cc7b63"
+  dependencies:
+    bitsyntax "~0.0.4"
+    bluebird "^3.4.6"
+    buffer-more-ints "0.0.2"
+    readable-stream "1.x >=1.1.9"
+    safe-buffer "^5.0.1"
+
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -71,6 +81,18 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+
+assertion-error@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
 babel-code-frame@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -79,9 +101,38 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+bitsyntax@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/bitsyntax/-/bitsyntax-0.0.4.tgz#eb10cc6f82b8c490e3e85698f07e83d46e0cba82"
+  dependencies:
+    buffer-more-ints "0.0.2"
+
+bluebird@^3.4.6:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
+boom@4.x.x:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
+  dependencies:
+    hoek "4.x.x"
+
+boom@5.x.x:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
+  dependencies:
+    hoek "4.x.x"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -98,6 +149,10 @@ buffer-from@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
 
+buffer-more-ints@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz#26b3885d10fa13db7fc01aae3aab870199e0124c"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -107,6 +162,17 @@ caller-path@^0.1.0:
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+
+chai@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -129,6 +195,10 @@ chalk@^2.0.0, chalk@^2.1.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -158,9 +228,19 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
+component-emitter@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -175,6 +255,14 @@ concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+cookiejar@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
+
+core-js@^2.4.0:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -187,11 +275,27 @@ cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cryptiles@3.x.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
+  dependencies:
+    boom "5.x.x"
+
 debug@3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
+
+deep-eql@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  dependencies:
+    type-detect "^4.0.0"
+
+deep-equal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -208,6 +312,10 @@ del@^2.0.2:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
 diff@3.5.0:
   version "3.5.0"
@@ -314,6 +422,10 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+extend@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
 external-editor@^2.0.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
@@ -356,6 +468,18 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+form-data@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
+formidable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -363,6 +487,10 @@ fs.realpath@^1.0.0:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
 glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
@@ -412,9 +540,22 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+hawk@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
+  dependencies:
+    boom "4.x.x"
+    cryptiles "3.x.x"
+    hoek "4.x.x"
+    sntp "2.x.x"
+
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+hoek@4.x.x:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
 iconv-lite@^0.4.17:
   version "0.4.21"
@@ -437,7 +578,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -488,6 +629,10 @@ is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -515,6 +660,10 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -522,7 +671,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -532,6 +681,24 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+methods@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+
+mime-types@^2.1.12:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+  dependencies:
+    mime-db "~1.33.0"
+
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -547,7 +714,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -580,6 +747,20 @@ mute-stream@0.0.7:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+nock@^9.2.5:
+  version "9.2.5"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.2.5.tgz#c131fc8d3c4723f386be0269739638be84733f2f"
+  dependencies:
+    chai "^4.1.2"
+    debug "^3.1.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.5"
+    mkdirp "^0.5.0"
+    propagate "^1.0.0"
+    qs "^6.5.1"
+    semver "^5.5.0"
 
 object-assign@^4.0.1:
   version "4.1.1"
@@ -620,6 +801,10 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -650,11 +835,34 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+promise@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
+  dependencies:
+    asap "~2.0.3"
+
+propagate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-readable-stream@^2.2.2:
+qs@^6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+
+"readable-stream@1.x >=1.1.9":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@^2.2.2, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -665,6 +873,10 @@ readable-stream@^2.2.2:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 regexpp@^1.0.1:
   version "1.1.0"
@@ -710,7 +922,7 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -718,7 +930,7 @@ safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-semver@^5.3.0:
+semver@^5.3.0, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -742,6 +954,18 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
+slugid@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/slugid/-/slugid-1.1.0.tgz#e09f00899c09f5a7058edc36dd49f046fd50a82a"
+  dependencies:
+    uuid "^2.0.1"
+
+sntp@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
+  dependencies:
+    hoek "4.x.x"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -752,6 +976,10 @@ string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -774,6 +1002,21 @@ strip-ansi@^4.0.0:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+superagent@~3.8.1:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
 
 supports-color@4.4.0:
   version "4.4.0"
@@ -802,6 +1045,24 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
+taskcluster-client@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-5.0.0.tgz#6171941188be26a7c32f18ff80bc17486f60f24f"
+  dependencies:
+    amqplib "^0.5.1"
+    babel-runtime "^6.26.0"
+    debug "^3.1.0"
+    hawk "^6.0.2"
+    lodash "^4.17.4"
+    promise "^8.0.1"
+    slugid "^1.1.0"
+    superagent "~3.8.1"
+    taskcluster-lib-urls "^1.0.0"
+
+taskcluster-lib-urls@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-urls/-/taskcluster-lib-urls-1.0.0.tgz#ebe6224384903d71b113bf26d63ff7cac48440b9"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -822,6 +1083,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -829,6 +1094,10 @@ typedarray@^0.0.6:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+uuid@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 which@^1.2.9:
   version "1.3.0"


### PR DESCRIPTION
This may not pass its tests, since it requires newer versions of other libraries to be landed, and those requirements are circular.

On a positive review, this will be squashed into a single commit, landed, all other GLU10 libraries `yarn upgrade`'d to 10.0.0, and this released as 10.0.0.

Background is in https://public.etherpad-mozilla.org/p/library-updates